### PR TITLE
Fix attrition charts data display

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@
     // Load Employee 360 View
     async function loadEmployee360Data() {
       try {
-        const metrics = await loadCSV('/hr_dashboard/data/employee360/metrics.csv');
+        const metrics = await loadCSV('data/ employee360/metrics.csv');
         const metricsContainer = document.getElementById('employee360-metrics');
         metricsContainer.innerHTML = metrics.map(m => `
           <div class="metric-card">
@@ -463,21 +463,21 @@
             ${m.change ? `<p class="text-sm opacity-90">${m.change}</p>` : ''}
           </div>`).join('');
 
-        const deptEmployees = await loadCSV('/hr_dashboard/data/employee360/department_employees.csv');
+        const deptEmployees = await loadCSV('data/ employee360/department_employees.csv');
         createBarChart('deptEmployeesChart',
           deptEmployees.map(d => d.department),
           deptEmployees.map(d => Number(d.total_employees)),
           'Total Employees'
         );
 
-        const deptNewEmployees = await loadCSV('data/employee360/department_new_employees.csv');
+        const deptNewEmployees = await loadCSV('data/ employee360/department_new_employees.csv');
         createBarChart('deptNewEmployeesChart',
           deptNewEmployees.map(d => d.department),
           deptNewEmployees.map(d => Number(d.new_employees)),
           'New Employees'
         );
 
-        const timeToHire = await loadCSV('data/employee360/time_to_hire.csv');
+        const timeToHire = await loadCSV('data/ employee360/time_to_hire.csv');
         createBarChart('timeToHireChart',
           timeToHire.map(d => d.department),
           timeToHire.map(d => Number(d.days_to_hire)),
@@ -492,7 +492,7 @@
     async function loadAttritionData() {
       try {
         // Cards
-        const metrics = await loadCSV('data/attrition/metrics.csv');
+        const metrics = await loadCSV('data/ attrition/metrics.csv');
         const metricsContainer = document.getElementById('attrition-metrics');
         metricsContainer.innerHTML = metrics.map(m => `
           <div class="metric-card">
@@ -502,13 +502,13 @@
           </div>`).join('');
 
         // Word Cloud - Top attrition reasons
-        const reasons = await loadCSV('data/attrition/reasons.csv');
+        const reasons = await loadCSV('data/ attrition/reasons.csv');
         const reasonsContainer = document.getElementById('attritionReasons');
         reasonsContainer.innerHTML = reasons.map(r => `
           <span style="font-size: ${Number(r.weight)}px; color: ${getRandomMagentaColor()};">${r.reason}</span>`).join('');
 
         // Department risk chart
-        const deptRisk = await loadCSV('data/attrition/department_risk.csv');
+        const deptRisk = await loadCSV('data/ attrition/department_risk.csv');
         createBarChart('departmentRiskChart',
           deptRisk.map(d => d.department),
           deptRisk.map(d => Number(d.risk_percentage)),
@@ -532,7 +532,7 @@
         for (const [category, file] of Object.entries(categories)) {
           const chartId = category + 'AttritionChart';
           try {
-            const dataCSV = await loadCSV(`data/attrition/${file}`);
+            const dataCSV = await loadCSV(`data/ attrition/${file}`);
             if (dataCSV.length > 0) {
               createBarChartWithHighlightFirst(chartId,
                 dataCSV.map(d => d.category),
@@ -545,7 +545,7 @@
         }
 
         // Word Cloud - Sentiment analysis
-        const sentiment = await loadCSV('data/attrition/sentiment.csv');
+        const sentiment = await loadCSV('data/ attrition/sentiment.csv');
         const sentimentContainer = document.getElementById('sentimentCloud');
         sentimentContainer.innerHTML = sentiment.map(s => `
           <span style="font-size: ${Number(s.weight)}px; color: ${getRandomMagentaColor()};">${s.sentiment}</span>
@@ -559,13 +559,13 @@
     // Load Talent Acquisition Looker
     async function loadTalentAcquisitionData() {
       try {
-        const joiningProb = await loadCSV('data/talent/joining_probability.csv');
+        const joiningProb = await loadCSV('data/ talent/joining_probability.csv');
         createHorizontalBarChart('joiningProbabilityChart',
           joiningProb.map(d => d.category),
           joiningProb.map(d => Number(d.percentage))
         );
 
-        const candidates = await loadCSV('data/talent/candidates.csv');
+        const candidates = await loadCSV('data/ talent/candidates.csv');
         const tbody = document.getElementById('candidateTableBody');
         tbody.innerHTML = candidates.map(c => {
           const pColor = getProbabilityColor(c.probability);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrected CSV file paths to enable data loading for all HR dashboard charts and word clouds.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous file paths omitted spaces in directory names (e.g., `data/ attrition/`), leading to 404 errors and preventing data from being displayed in the visualizations.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa3b06ec-c75c-495d-b4b3-3de2d2c414ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa3b06ec-c75c-495d-b4b3-3de2d2c414ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>