### PR TITLE
Investigate missing data in attrition looker views

### DIFF
--- a/script.js
+++ b/script.js
@@ -308,15 +308,15 @@ async function loadAttritionData() {
         // Load CSV data for charts
         const chartConfigs = [
             { file: 'department_risk.csv', chartId: 'deptAttritionChart', labelKey: 'department', dataKey: 'risk_percentage' },
-            { file: 'gender.csv', chartId: 'genderAttritionChart', labelKey: 'gender', dataKey: 'attrition_count' },
-            { file: 'grade.csv', chartId: 'gradeAttritionChart', labelKey: 'grade', dataKey: 'attrition_count' },
-            { file: 'designation.csv', chartId: 'designationAttritionChart', labelKey: 'designation', dataKey: 'attrition_count' },
-            { file: 'tenure.csv', chartId: 'tenureAttritionChart', labelKey: 'tenure', dataKey: 'attrition_count' },
-            { file: 'business_unit.csv', chartId: 'businessUnitAttritionChart', labelKey: 'business_unit', dataKey: 'attrition_count' },
-            { file: 'manager.csv', chartId: 'managerAttritionChart', labelKey: 'manager', dataKey: 'attrition_count' },
-            { file: 'rating.csv', chartId: 'ratingAttritionChart', labelKey: 'rating', dataKey: 'attrition_count' },
-            { file: 'hometown.csv', chartId: 'hometownAttritionChart', labelKey: 'hometown_tier', dataKey: 'attrition_count' },
-            { file: 'age.csv', chartId: 'ageAttritionChart', labelKey: 'age_group', dataKey: 'attrition_count' },
+            { file: 'gender.csv', chartId: 'genderAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'grade.csv', chartId: 'gradeAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'designation.csv', chartId: 'designationAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'tenure.csv', chartId: 'tenureAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'business_unit.csv', chartId: 'businessUnitAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'manager.csv', chartId: 'managerAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'rating.csv', chartId: 'ratingAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'hometown.csv', chartId: 'hometownAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'age.csv', chartId: 'ageAttritionChart', labelKey: 'category', dataKey: 'attrition' },
             { file: 'commute.csv', chartId: 'distanceAttritionChart', labelKey: 'category', dataKey: 'attrition' }
         ];
         


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update attrition chart configurations to match actual CSV column names, resolving "no data" display in Looker views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The JavaScript configuration expected specific column names (e.g., 'gender', 'grade') and 'attrition_count' for various attrition charts. However, the actual data files in `data/ attrition/` consistently use 'category' for all dimension columns and 'attrition' for the count. This mismatch prevented the charts from rendering any data.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e8e23bd-a3d6-419d-b410-ce2b9d6bf4d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e8e23bd-a3d6-419d-b410-ce2b9d6bf4d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>