### PR TITLE
Fix attrition looker data mappings

### DIFF
--- a/script.js
+++ b/script.js
@@ -314,10 +314,10 @@ async function loadAttritionData() {
             { file: 'tenure.csv', chartId: 'tenureAttritionChart', labelKey: 'category', dataKey: 'attrition' },
             { file: 'business_unit.csv', chartId: 'businessUnitAttritionChart', labelKey: 'category', dataKey: 'attrition' },
             { file: 'manager.csv', chartId: 'managerAttritionChart', labelKey: 'category', dataKey: 'attrition' },
-            { file: 'rating.csv', chartId: 'ratingAttritionChart', labelKey: 'category', dataKey: 'attrition' },
             { file: 'hometown.csv', chartId: 'hometownAttritionChart', labelKey: 'category', dataKey: 'attrition' },
             { file: 'age.csv', chartId: 'ageAttritionChart', labelKey: 'category', dataKey: 'attrition' },
-            { file: 'commute.csv', chartId: 'distanceAttritionChart', labelKey: 'category', dataKey: 'attrition' }
+            { file: 'distance.csv', chartId: 'distanceAttritionChart', labelKey: 'category', dataKey: 'attrition' },
+            { file: 'rating.csv', chartId: 'ratingAttritionChart', labelKey: 'category', dataKey: 'attrition' }
         ];
         
         for (const config of chartConfigs) {


### PR DESCRIPTION
Corrected dataset mappings for Attrition Looker charts to align with specified data sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-28f4b56b-6095-4945-b57e-f6c620fdf659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28f4b56b-6095-4945-b57e-f6c620fdf659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>