### PR TITLE
Replace attrition reasons with sentiment analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
             <!-- Charts Section -->
             <div class="charts-container">
                 <div class="chart-wrapper full-width">
-                    <h3>Top Reasons for Attrition (Company-wide)</h3>
-                    <div id="attritionReasonsWordcloud"></div>
+                    <h3>Top Reasons for Attrition (Sentiment Analysis)</h3>
+                    <div id="sentimentWordcloud"></div>
                 </div>
                 
                 <div class="chart-wrapper">
@@ -151,11 +151,6 @@
                 <div class="chart-wrapper">
                     <h3>Expected Attrition by Commutation Distance</h3>
                     <canvas id="distanceAttritionChart"></canvas>
-                </div>
-                
-                <div class="chart-wrapper full-width">
-                    <h3>Top Reasons for Attrition (Sentiment Analysis)</h3>
-                    <div id="sentimentWordcloud"></div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -285,16 +285,6 @@ async function loadAttritionData() {
             document.getElementById('attritionRisk').textContent = metricsData[0].value;
         }
         
-        // Load word cloud data from reasons.csv for company-wide attrition reasons
-        const reasonsData = await loadCSV('data/attrition/reasons.csv');
-        if (reasonsData.length > 0) {
-            const attritionReasons = reasonsData.map(item => ({
-                text: item.reason,
-                size: Math.max(12, Math.min(26, parseInt(item.weight)))
-            }));
-            createWordCloud('attritionReasonsWordcloud', attritionReasons);
-        }
-        
         // Load word cloud data from sentiment.csv for sentiment analysis
         const sentimentData = await loadCSV('data/attrition/sentiment.csv');
         if (sentimentData.length > 0) {

--- a/styles.css
+++ b/styles.css
@@ -196,7 +196,6 @@ header p {
 }
 
 /* Word Cloud Styles */
-#attritionReasonsWordcloud,
 #sentimentWordcloud {
     min-height: 250px;
     background: linear-gradient(135deg, #fdf2f8 0%, #fce7f3 100%);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replace "Top Reasons for Attrition (Company-wide)" with "Top Reasons for Attrition (Sentiment Analysis)" to display sentiment-based insights.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous "Company-wide" word cloud attempted to load data from a non-existent `reasons.csv` file, rendering it non-functional. This PR replaces it with the existing sentiment analysis word cloud, which correctly loads data from `sentiment.csv`, providing relevant insights as per the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-c33f5ac1-434d-4f5a-b182-87ab7ecc03b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c33f5ac1-434d-4f5a-b182-87ab7ecc03b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>